### PR TITLE
fix: grpc endpoint

### DIFF
--- a/how-to/logs-collection/yoda/otel-config.yaml
+++ b/how-to/logs-collection/yoda/otel-config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
 exporters:
   debug:
     verbosity: detailed


### PR DESCRIPTION
Hello! 
Your tutorial was very helpful for me. I found that the new version of the collector no longer uses 0.0.0.0 as the default, so in this MR, I fixed it. You can find more information about the update at: https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.104.0